### PR TITLE
Alterações para a biblioteca funcionar no Wildfly

### DIFF
--- a/src/main/java/com/clicksign/models/Document.java
+++ b/src/main/java/com/clicksign/models/Document.java
@@ -20,6 +20,10 @@ public class Document extends ClicksignResource {
 	String userKey;
 	SignatureList list;
 
+	public Document() {
+		super();
+	}
+
 	public Document(String key, String originalName, String status, Date createdAt, Date updatedAt, String userKey,
 			SignatureList list) {
 		super();

--- a/src/main/java/com/clicksign/models/Signature.java
+++ b/src/main/java/com/clicksign/models/Signature.java
@@ -1,8 +1,9 @@
 package com.clicksign.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class Signature {
+public class Signature implements Serializable {
 	String displayName;
 	String title;
 	String companyName;
@@ -15,6 +16,10 @@ public class Signature {
 	Date signedAt;
 	Date createdAt;
 	Date updatedAt;
+
+	public Signature() {
+		super();
+	}
 
 	public Signature(String email, String act) {
 		super();

--- a/src/main/java/com/clicksign/models/SignatureList.java
+++ b/src/main/java/com/clicksign/models/SignatureList.java
@@ -1,14 +1,19 @@
 package com.clicksign.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-public class SignatureList {
+public class SignatureList implements Serializable{
 	Date createdAt;
 	Date startedAt;
 	Date updatedAt;
 	String userKey;
 	List<Signature> signatures;
+
+	public SignatureList() {
+		super();
+	}
 
 	public SignatureList(Date createdAt, Date startedAt, Date updatedAt, String userKey, List<Signature> signatures) {
 		super();

--- a/src/main/java/com/clicksign/net/ClicksignResource.java
+++ b/src/main/java/com/clicksign/net/ClicksignResource.java
@@ -3,6 +3,7 @@ package com.clicksign.net;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +40,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public class ClicksignResource {
+public class ClicksignResource implements Serializable {
 	public static final String CHARSET = "UTF-8";
 
 	private static final String USER_AGENT = String.format("Clicksign/Java %s", Clicksign.VERSION);
@@ -57,6 +58,10 @@ public class ClicksignResource {
 
 	protected enum RequestMethod {
 		GET, POST, DELETE, PUT
+	}
+
+	public ClicksignResource(){
+		super();
 	}
 
 	protected static InputStream getDownloadInputStream(String url, String accessToken) throws ClicksignException {


### PR DESCRIPTION
Segundo pude verificar as alterações são necessárias para que os objetos possam ser serializados e desserializados com sucesso.

Antes da alteração estava acontecendo a seguinte mensagem de erro:
 java.lang.RuntimeException: Unable to invoke no-args constructor for class com.clicksign.models.Signature.

Depois da alteração, o erro foi resolvido.